### PR TITLE
Crk 10603 - Fix issues with `merge()` and null/empty values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ configure(subprojects.findAll { it.name != 'util' }) {
     apply plugin: 'jacoco'
     apply plugin: 'optional-base'
 
-    group = 'org.mongodb.morphia'
+    group = 'com.github.fwHub'
     sourceCompatibility = JavaVersion.VERSION_1_6
     targetCompatibility = JavaVersion.VERSION_1_6
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 latest_release=1.3.2
-version=1.3.3-SNAPSHOT
+version=1.3.2+com.cirkus.1
 slf4jVersion=1.7.5
 driverVersion=3.4.0
 ztExecVersion=1.5

--- a/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
@@ -1556,8 +1556,8 @@ public class DatastoreImpl implements AdvancedDatastore {
      * Moves nulls and empties from the dbObj onto the unsetDbObj if corresponding mapper options
      * are enabled.
      *
-     * @param dbObj The document for which nulls/empty fields are moved from
-     * @param unsetDbObj The document for which null/empty fields are moved to
+     * @param dbObj The document from which nulls/empty fields are moved
+     * @param unsetDbObj The document where null/empty fields are moved to
      */
     private void handleUnsetValues(final DBObject dbObj, final DBObject unsetDbObj) {
         if (mapper.getOptions().isUnsetNulls() || mapper.getOptions().isUnsetEmpties()) {

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/EmbeddedMapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/EmbeddedMapper.java
@@ -249,6 +249,8 @@ class EmbeddedMapper implements CustomMapper {
             if (!values.isEmpty() || mapper.getOptions().isStoreEmpties()) {
                 dbObject.put(name, values);
             }
+        } else if (mapper.getOptions().isStoreNulls()) {
+            dbObject.put(name, null);
         }
     }
 
@@ -296,6 +298,8 @@ class EmbeddedMapper implements CustomMapper {
             if (!values.isEmpty() || mapper.getOptions().isStoreEmpties()) {
                 dbObject.put(name, values);
             }
+        } else if (mapper.getOptions().isStoreNulls()) {
+            dbObject.put(name, null);
         }
     }
 

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/MapperOptions.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/MapperOptions.java
@@ -268,16 +268,16 @@ public class MapperOptions {
     }
 
     /**
-     * @return true if Morphia should use $unset operator for lists/maps/sets/arrays
+     * @return true if Morphia should use $unset operator for empty lists/maps/sets/arrays
      */
     public boolean isUnsetEmpties() {
         return unsetEmpties;
     }
 
     /**
-     * Controls if Morphia should should use $unset operator for lists/maps/sets/arrays
+     * Controls if Morphia should should use $unset operator for empty lists/maps/sets/arrays
      *
-     * @param unsetEmpties true if Morphia should should use $unset operator for lists/maps/sets/arrays
+     * @param unsetEmpties true if Morphia should should use $unset operator for empty lists/maps/sets/arrays
      */
     public void setUnsetEmpties(final boolean unsetEmpties) {
         this.unsetEmpties = unsetEmpties;

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/MapperOptions.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/MapperOptions.java
@@ -24,6 +24,8 @@ public class MapperOptions {
     private boolean ignoreFinals; //ignore final fields.
     private boolean storeNulls;
     private boolean storeEmpties;
+    private boolean unsetNulls;
+    private boolean unsetEmpties;
     private boolean useLowerCaseCollectionNames;
     private boolean cacheClassLookups = false;
     private boolean mapSubPackages = false;
@@ -263,6 +265,38 @@ public class MapperOptions {
      */
     public void setStoreNulls(final boolean storeNulls) {
         this.storeNulls = storeNulls;
+    }
+
+    /**
+     * @return true if Morphia should use $unset operator for lists/maps/sets/arrays
+     */
+    public boolean isUnsetEmpties() {
+        return unsetEmpties;
+    }
+
+    /**
+     * Controls if Morphia should should use $unset operator for lists/maps/sets/arrays
+     *
+     * @param unsetEmpties true if Morphia should should use $unset operator for lists/maps/sets/arrays
+     */
+    public void setUnsetEmpties(final boolean unsetEmpties) {
+        this.unsetEmpties = unsetEmpties;
+    }
+
+    /**
+     * @return true if Morphia should use $unset operator for null values
+     */
+    public boolean isUnsetNulls() {
+        return unsetNulls;
+    }
+
+    /**
+     * Controls if Morphia should use $unset operator for null values.
+     *
+     * @param unsetNulls true if Morphia should use $unset operator for null values
+     */
+    public void setUnsetNulls(final boolean unsetNulls) {
+        this.unsetNulls = unsetNulls;
     }
 
     /**

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/ReferenceMapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/ReferenceMapper.java
@@ -240,13 +240,15 @@ class ReferenceMapper implements CustomMapper {
             if (!values.isEmpty() || mapper.getOptions().isStoreEmpties()) {
                 dbObject.put(name, values);
             }
+        } else if (mapper.getOptions().isStoreNulls()) {
+            dbObject.put(name, null);
         }
     }
 
     private void writeMap(final MappedField mf, final DBObject dbObject, final String name, final Object fieldValue,
                           final Reference refAnn, final Mapper mapper) {
         final Map<Object, Object> map = (Map<Object, Object>) fieldValue;
-        if ((map != null)) {
+        if (map != null) {
             final Map values = mapper.getOptions().getObjectFactory().createMap(mf);
 
             if (ProxyHelper.isProxy(map) && ProxyHelper.isUnFetched(map)) {
@@ -270,6 +272,8 @@ class ReferenceMapper implements CustomMapper {
             if (!values.isEmpty() || mapper.getOptions().isStoreEmpties()) {
                 dbObject.put(name, values);
             }
+        } else if (mapper.getOptions().isStoreNulls()) {
+            dbObject.put(name, null);
         }
     }
 

--- a/morphia/src/main/java/org/mongodb/morphia/query/UpdateOpsImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/UpdateOpsImpl.java
@@ -219,8 +219,19 @@ public class UpdateOpsImpl<T> implements UpdateOperations<T> {
         if (value == null) {
             throw new QueryException("Value cannot be null.");
         }
-
-        add(UpdateOperator.SET, field, value, true);
+        boolean unset = false;
+        if (mapper.getOptions().isUnsetEmpties()) {
+            if (value instanceof Iterable && !((Iterable) value).iterator().hasNext()) {
+                unset = true;
+            } else if (value instanceof Map && ((Map) value).isEmpty()) {
+                unset = true;
+            }
+        }
+        if (unset) {
+            unset(field);
+        } else {
+            add(UpdateOperator.SET, field, value, true);
+        }
         return this;
     }
 


### PR DESCRIPTION
## Cirkus Task

- Number: 10603

### Fix Morphia issues with storing nulls/empties

This PR adds extended support for handling `nulls` and `empty arrays`.
When Morphia is configured with `storeNulls: false` and `storeEmpties: false`, Morphia ignores these values completely when using `Datastore.merge()`. Also, the `storeNulls` option only handles single values (not arrays) so there is no way whatsoever to deal with scenarios where an array is `null`.

These issue have been resolved in 2 steps:
- Fixed so that `storeNulls` also deal with null arrays.
- Added two new boolean options called `unsetNulls` and `unsetEmpties`. If these are set to true in combination with `storeNulls` and `storeEmpties`set to true, then Morphia will perform an `$unset` on null/empty values instead of storing them.
